### PR TITLE
「カスタムで追加」したアバターが存在する場合、「対応アバター選択」画面でエラーで終了してしまうのを修正

### DIFF
--- a/Forms/SelectSupportedAvatar.cs
+++ b/Forms/SelectSupportedAvatar.cs
@@ -37,7 +37,7 @@ namespace Avatar_Explorer.Forms
             PictureBox pictureBox = new PictureBox();
             pictureBox.Size = new Size(56, 56);
             pictureBox.SizeMode = PictureBoxSizeMode.StretchImage;
-            pictureBox.Image = Image.FromFile(item.ImagePath);
+            pictureBox.Image = File.Exists(item.ImagePath) ? Image.FromFile(item.ImagePath) : Image.FromFile("./Datas/FileIcon.png");
             pictureBox.Location = new Point(3, 3);
             button.Controls.Add(pictureBox);
 


### PR DESCRIPTION
「アイテムの追加」画面でアバターを「カスタムで追加」ボタンで追加した場合、
「対応アバター選択」画面でエラーが発生し終了してしまうバグを見つけましたので、修正しました。
（画像ファイルが存在しない場合にも有効です）