### PR TITLE
:wrench: ビルド時にフォントファイルを成果物フォルダにコピーする設定の追加

### DIFF
--- a/Avatar Explorer.csproj
+++ b/Avatar Explorer.csproj
@@ -16,10 +16,25 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <Content Include="icon.ico" />
+		<Content Include="icon.ico" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="HtmlAgilityPack" Version="1.11.71" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Update="Font Files\NotoSans-Regular.ttf">
+			<Link>Datas/NotoSans-Regular.ttf</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="Font Files\NotoSansJP-Regular.ttf">
+			<Link>Datas/NotoSansJP-Regular.ttf</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="Font Files\NotoSansKR-Regular.ttf">
+			<Link>Datas/NotoSansKR-Regular.ttf</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
## 概要

Visual Studioでのデバッグ実行時に `Datas/` 以下のフォントファイル参照エラーが発生するため、ビルド時に成果物フォルダ ( `./bin/Debug/net8.0-windows` ) にフォントファイルをコピーする設定を追加しました。

フォントをインストールしている場合は発生しませんが、手元でインストールしていなかったため、開発利便性という意味でPRを作成しました。
不要であればcloseください。

## 変更後ファイルツリー

```
Avatar-Explorer/bin
└─Debug
    └─net8.0-windows
        │  Avatar Explorer.deps.json
        │  Avatar Explorer.dll
        │  Avatar Explorer.exe
        │  Avatar Explorer.pdb
        │  Avatar Explorer.runtimeconfig.json
        │  HtmlAgilityPack.dll
        │
        ├─Datas
        │      ItemsData.json
        │      NotoSans-Regular.ttf
        │      NotoSansJP-Regular.ttf
        │      NotoSansKR-Regular.ttf
        │
        └─Font Files
```