### PR TITLE
アイテム一覧のボタンの挙動を調整

### DIFF
--- a/Classes/CustomItemButton.cs
+++ b/Classes/CustomItemButton.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-
-namespace Avatar_Explorer.Classes
+﻿namespace Avatar_Explorer.Classes
 {
     internal class CustomItemButton : Button
     {

--- a/Classes/CustomItemButton.cs
+++ b/Classes/CustomItemButton.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace Avatar_Explorer.Classes
+{
+    internal class CustomItemButton : Button
+    {
+        private PictureBox _pictureBox;
+        private Label _title;
+        private Label _authorName;
+        private string _toolTipText;
+        private ToolTip _toolTip;
+
+        public Image Picture
+        {
+            get => _pictureBox.Image;
+            set => _pictureBox.Image = value;
+        }
+
+        public string TitleText
+        {
+            get => _title.Text;
+            set => _title.Text = value;
+        }
+
+        public string AuthorName
+        {
+            get => _authorName.Text;
+            set => _authorName.Text = value;
+        }
+
+        public string ToolTipText
+        {
+            get => _toolTipText;
+            set
+            {
+                _toolTipText = value;
+                _toolTip.SetToolTip(this, _toolTipText);
+            }
+        }
+
+        public CustomItemButton(bool isAvatarSelectButton, int buttonWidth)
+        {
+            Size = new Size(buttonWidth, 64);
+
+            _pictureBox = new PictureBox();
+            if (isAvatarSelectButton)
+            {
+                // アバター選択画面で画像の位置が異なる
+                _pictureBox.Location = new Point(3, 3);
+            } else {
+                _pictureBox.Location = new Point(4, 4);
+            }
+            _pictureBox.Size = new Size(56, 56);
+            _pictureBox.SizeMode = PictureBoxSizeMode.StretchImage;
+            Controls.Add(_pictureBox);
+
+            // タイトルが長すぎる場合にボタンの幅を超えないようにする
+            // ボタンの幅 - ラベルのX位置 - 余裕を持たせて数px引く
+            var labelWidth = buttonWidth - 60 - 5;
+
+            _title = new Label();
+            _title.Location = new Point(60, 3);
+            _title.Size = new Size(labelWidth, 20);
+            _title.Font = new Font("Yu Gothic UI", 12F);
+            Controls.Add(_title);
+
+            _authorName = new Label();
+            _authorName.Location = new Point(60, 25);
+            _authorName.Size = new Size(labelWidth, 20);
+            Controls.Add(_authorName);
+
+            _toolTipText = "";
+            _toolTip = new ToolTip();
+
+            // 画像とラベルのイベントが発生した際にボタンのイベントを呼び出す
+            foreach (Control control in Controls)
+            {
+                control.MouseEnter += (s, e) => OnMouseEnter(e);
+                control.MouseLeave += (s, e) => OnMouseLeave(e);
+                control.MouseMove += (s, e) => OnMouseMove(e);
+                control.MouseDown += (s, e) => OnMouseDown(e);
+                control.MouseClick += (s, e) => OnMouseClick(e);
+            }
+        }
+
+        protected override void OnClick(EventArgs e)
+        {
+            // ここではクリックされたボタンの種類を取得できないため、何もしない（OnMouseClickで行う）
+        }
+
+        protected override void OnMouseClick(MouseEventArgs e)
+        {
+            // 左クリックされた場合
+            if (e.Button == MouseButtons.Left)
+                ProcessClick();
+            base.OnMouseClick(e);
+        }
+
+        protected override void OnPreviewKeyDown(PreviewKeyDownEventArgs e)
+        {
+            // エンターキーまたはスペースキーを押下された場合
+            if (e.KeyCode == Keys.Enter || e.KeyCode == Keys.Space)
+                ProcessClick();
+            base.OnPreviewKeyDown(e);
+        }
+
+        private void ProcessClick()
+        {
+            // 画像・ラベルをクリックされた場合に備えてフォーカスをボタンに移動させる
+            Focus();
+            // button.Click += で追加されたイベントを実行する
+            base.OnClick(EventArgs.Empty);
+        }
+    }
+}

--- a/Classes/Helper.cs
+++ b/Classes/Helper.cs
@@ -121,38 +121,16 @@ namespace Avatar_Explorer.Classes
             return itemFolderInfo;
         }
 
-        public static Button CreateButton(string imagePath, string labelTitle, string? deskription, bool @short = false, string tooltip = "")
+        public static Button CreateButton(string imagePath, string labelTitle, string? description, bool @short = false, string tooltip = "")
         {
             var buttonWidth = @short ? 303 : 874;
-            Button button = new Button();
-            button.Size = new Size(buttonWidth, 64);
-
-            PictureBox pictureBox = new PictureBox();
-            pictureBox.Size = new Size(56, 56);
-            pictureBox.SizeMode = PictureBoxSizeMode.StretchImage;
-            pictureBox.Image = ResizeImage(File.Exists(imagePath) ? imagePath : "./Datas/FileIcon.png", 100, 100);
-            pictureBox.Location = new Point(4, 4);
-            button.Controls.Add(pictureBox);
-
-            Label title = new Label();
-            title.Text = labelTitle;
-            title.Location = new Point(60, 3);
-            title.AutoSize = true;
-            title.Font = new Font("Yu Gothic UI", 12F);
-            button.Controls.Add(title);
-
-            Label authorName = new Label();
-            authorName.Text = deskription;
-            authorName.Location = new Point(60, 25);
-            authorName.Size = new Size(200, 20);
-            button.Controls.Add(authorName);
-
-            pictureBox.Click += (_, _) => button.PerformClick();
-            title.Click += (_, _) => button.PerformClick();
-            authorName.Click += (_, _) => button.PerformClick();
-
+            CustomItemButton button = new CustomItemButton(false, buttonWidth);
+            button.Picture = ResizeImage(File.Exists(imagePath) ? imagePath : "./Datas/FileIcon.png", 100, 100);
+            button.TitleText = labelTitle;
+            if (description != null)
+                button.AuthorName = description;
             if (!string.IsNullOrEmpty(tooltip))
-                new ToolTip().SetToolTip(button, tooltip);
+                button.ToolTipText = tooltip;
 
             return button;
         }

--- a/Forms/SelectSupportedAvatar.cs
+++ b/Forms/SelectSupportedAvatar.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.InteropServices.JavaScript;
 using Avatar_Explorer.Classes;
 
 namespace Avatar_Explorer.Forms
@@ -48,41 +49,16 @@ namespace Avatar_Explorer.Forms
 
         private static Button CreateAvatarButton(Item item, string language)
         {
-            Button button = new Button();
-            button.Size = new Size(1009, 64);
-
-            PictureBox pictureBox = new PictureBox();
-            pictureBox.Size = new Size(56, 56);
-            pictureBox.SizeMode = PictureBoxSizeMode.StretchImage;
-            pictureBox.Image = File.Exists(item.ImagePath) ? Image.FromFile(item.ImagePath) : Image.FromFile("./Datas/FileIcon.png");
-            pictureBox.Location = new Point(3, 3);
-            button.Controls.Add(pictureBox);
-
-            Label title = new Label();
-            title.Text = item.Title;
-            title.Location = new Point(60, 3);
-            title.AutoSize = true;
-            title.Font = new Font("Yu Gothic UI", 12F);
-            button.Controls.Add(title);
-
-            Label authorName = new Label();
-            authorName.Text = Helper.Translate("作者: ", language) + item.AuthorName;
-            authorName.Location = new Point(60, 25);
-            authorName.Size = new Size(200, 20);
-
-            button.Controls.Add(authorName);
-
-            pictureBox.Click += (_, _) => button.PerformClick();
-            title.Click += (_, _) => button.PerformClick();
-            authorName.Click += (_, _) => button.PerformClick();
+            CustomItemButton button = new CustomItemButton(true, 1009);
+            button.Picture = File.Exists(item.ImagePath) ? Image.FromFile(item.ImagePath) : Image.FromFile("./Datas/FileIcon.png");
+            button.TitleText = item.Title;
+            button.AuthorName = Helper.Translate("作者: ", language) + item.AuthorName; ;
+            button.ToolTipText = item.Title;
 
             button.Click += (_, _) =>
             {
                 button.BackColor = button.BackColor == Color.LightGreen ? Color.FromKnownColor(KnownColor.Control) : Color.LightGreen;
             };
-
-            ToolTip toolTip = new ToolTip();
-            toolTip.SetToolTip(button, item.Title);
 
             return button;
         }

--- a/Forms/SelectSupportedAvatar.cs
+++ b/Forms/SelectSupportedAvatar.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.InteropServices.JavaScript;
 using Avatar_Explorer.Classes;
 
 namespace Avatar_Explorer.Forms


### PR DESCRIPTION
アイテム一覧のボタンの調整を行いました
- 右クリックした際、項目によってメニューの表示と項目を開く動作が混在しているのを調整
  - ボタン内の画像とラベルが右クリック・ホイールクリックで反応していた
    - 右クリックで反応していたのはContextMenuを使用していないボタン
  - 調整後の項目を開く動作は左クリックで統一させてます
- ボタンをホバーした後、ボタン内の画像とラベルにマウスカーソルを移動すると装飾がホバー前の状態に切り替わるのを調整
- ボタン用のクラスを作成し、ヘルパー内とアバター選択画面内にあったボタン生成処理を1か所にまとめた
- タイトルと作成者ラベルの幅を微調整
  - タイトルが長いとボタンの枠ギリギリまで表示されてたので、少し内側で収まるように調整してます。
  - 不要でしたら戻してもらって全然大丈夫です。

