### PR TITLE
ボタンの画像表示のメモリリークを修正

### DIFF
--- a/Classes/CustomItemButton.cs
+++ b/Classes/CustomItemButton.cs
@@ -8,6 +8,7 @@
         private readonly ToolTip _toolTip;
         private string _toolTipText;
         private Form? _previewForm;
+        private PictureBox? _previewPictureBox;
 
         public Image Picture
         {
@@ -107,14 +108,14 @@
                     TopMost = true
                 };
 
-                var previewPictureBox = new PictureBox
+                _previewPictureBox = new PictureBox
                 {
                     Dock = DockStyle.Fill,
                     Image = Image.FromFile(ImagePath),
                     SizeMode = PictureBoxSizeMode.StretchImage
                 };
 
-                _previewForm.Controls.Add(previewPictureBox);
+                _previewForm.Controls.Add(_previewPictureBox);
 
                 var cursorPosition = Cursor.Position;
                 var screenBounds = Screen.FromPoint(cursorPosition).WorkingArea;
@@ -137,6 +138,21 @@
             _previewForm.Close();
             _previewForm.Dispose();
             _previewForm = null;
+
+            // 画像のメモリ開放
+            if (_previewPictureBox != null)
+            {
+                if (_previewPictureBox.Image != null)
+                {
+                    if (!SharedImages.IsSharedImage(_previewPictureBox.Image))
+                    {
+                        _previewPictureBox.Image.Dispose();
+                    }
+                    _previewPictureBox.Image = null;
+                }
+                _previewPictureBox.Dispose();
+                _previewPictureBox = null;
+            }
         }
 
         protected override void OnClick(EventArgs e)
@@ -166,6 +182,32 @@
             Focus();
             // button.Click += で追加されたイベントを実行する
             base.OnClick(EventArgs.Empty);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            // リソースの解放
+            if (disposing)
+            {
+                if (_pictureBox != null)
+                {
+                    if(_pictureBox.Image != null)
+                    {
+                        if (!SharedImages.IsSharedImage(_pictureBox.Image))
+                        {
+                            _pictureBox.Image.Dispose();
+                        }
+                        _pictureBox.Image = null;
+                    }
+                    _pictureBox.Dispose();
+                }
+                _title?.Dispose();
+                _authorName?.Dispose();
+                _toolTip?.Dispose();
+                _previewForm?.Dispose();
+            }
+
+            base.Dispose(disposing);
         }
     }
 }

--- a/Classes/Helper.cs
+++ b/Classes/Helper.cs
@@ -8,8 +8,6 @@ namespace Avatar_Explorer.Classes
     {
         private static readonly HttpClient HttpClient = new();
         private static readonly Dictionary<string, Dictionary<string, string>> TranslateData = new();
-        private static readonly Image FileImage = Image.FromStream(new MemoryStream(Properties.Resources.FileIcon));
-        private static readonly Image FolderImage = Image.FromStream(new MemoryStream(Properties.Resources.FolderIcon));
 
         public static async Task<Item> GetBoothItemInfoAsync(string id)
         {
@@ -123,11 +121,11 @@ namespace Avatar_Explorer.Classes
 
             if (imagePath == null)
             {
-                button.Picture = FolderImage;
+                button.Picture = SharedImages.GetSharedImage(SharedImages.Images.FolderIcon);
             }
             else
             {
-                button.Picture = File.Exists(imagePath) ? ResizeImage(imagePath, 100, 100) : FileImage;
+                button.Picture = File.Exists(imagePath) ? ResizeImage(imagePath, 100, 100) : SharedImages.GetSharedImage(SharedImages.Images.FileIcon);
             }
 
             button.ImagePath = imagePath;

--- a/Classes/Helper.cs
+++ b/Classes/Helper.cs
@@ -121,11 +121,11 @@ namespace Avatar_Explorer.Classes
 
             if (imagePath == null)
             {
-                button.Picture = SharedImages.GetSharedImage(SharedImages.Images.FolderIcon);
+                button.Picture = SharedImages.GetImage(SharedImages.Images.FolderIcon);
             }
             else
             {
-                button.Picture = File.Exists(imagePath) ? ResizeImage(imagePath, 100, 100) : SharedImages.GetSharedImage(SharedImages.Images.FileIcon);
+                button.Picture = File.Exists(imagePath) ? ResizeImage(imagePath, 100, 100) : SharedImages.GetImage(SharedImages.Images.FileIcon);
             }
 
             button.ImagePath = imagePath;

--- a/Classes/SharedImages.cs
+++ b/Classes/SharedImages.cs
@@ -19,7 +19,7 @@
             OpenIcon
         };
 
-        public static Image GetSharedImage(Images images)
+        public static Image GetImage(Images images)
         {
             Image sharedImage = images switch
             {

--- a/Classes/SharedImages.cs
+++ b/Classes/SharedImages.cs
@@ -1,0 +1,49 @@
+﻿namespace Avatar_Explorer.Classes
+{
+    public class SharedImages
+    {
+        private static readonly Image FileImage = Image.FromStream(new MemoryStream(Properties.Resources.FileIcon));
+        private static readonly Image FolderImage = Image.FromStream(new MemoryStream(Properties.Resources.FolderIcon));
+        private static readonly Image CopyImage = Image.FromStream(new MemoryStream(Properties.Resources.CopyIcon));
+        private static readonly Image TrashImage = Image.FromStream(new MemoryStream(Properties.Resources.TrashIcon));
+        private static readonly Image EditImage = Image.FromStream(new MemoryStream(Properties.Resources.EditIcon));
+        private static readonly Image OpenImage = Image.FromStream(new MemoryStream(Properties.Resources.OpenIcon));
+
+        public enum Images
+        {
+            FileIcon,
+            FolderIcon,
+            CopyIcon,
+            TrashIcon,
+            EditIcon,
+            OpenIcon
+        };
+
+        public static Image GetSharedImage(Images images)
+        {
+            Image sharedImage = images switch
+            {
+                Images.FileIcon => FileImage,
+                Images.FolderIcon => FolderImage,
+                Images.CopyIcon => CopyImage,
+                Images.TrashIcon => TrashImage,
+                Images.EditIcon => EditImage,
+                Images.OpenIcon => OpenImage,
+                _ => throw new ArgumentOutOfRangeException(nameof(images), images, "共有画像の定義がありません")
+            };
+            return sharedImage;
+        }
+
+        public static bool IsSharedImage(Image image)
+        {
+            if(image == FileImage
+                || image == FolderImage 
+                || image == CopyImage 
+                || image == TrashImage 
+                || image == EditImage 
+                || image == OpenImage)
+                return true;
+            return false;
+        }
+    }
+}

--- a/Forms/Main.cs
+++ b/Forms/Main.cs
@@ -116,7 +116,7 @@ namespace Avatar_Explorer.Forms
                 if (item.BoothId != -1)
                 {
                     ToolStripMenuItem toolStripMenuItem =
-                        new(Helper.Translate("Boothリンクのコピー", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.CopyIcon));
+                        new(Helper.Translate("Boothリンクのコピー", CurrentLanguage), SharedImages.GetImage(SharedImages.Images.CopyIcon));
                     toolStripMenuItem.Click += (_, _) =>
                     {
                         try
@@ -132,7 +132,7 @@ namespace Avatar_Explorer.Forms
                     };
 
                     ToolStripMenuItem toolStripMenuItem1 =
-                        new(Helper.Translate("Boothリンクを開く", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.CopyIcon));
+                        new(Helper.Translate("Boothリンクを開く", CurrentLanguage), SharedImages.GetImage(SharedImages.Images.CopyIcon));
                     toolStripMenuItem1.Click += (_, _) =>
                     {
                         try
@@ -151,7 +151,7 @@ namespace Avatar_Explorer.Forms
                     contextMenuStrip.Items.Add(toolStripMenuItem1);
                 }
 
-                ToolStripMenuItem toolStripMenuItem2 = new(Helper.Translate("サムネイル変更", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.EditIcon));
+                ToolStripMenuItem toolStripMenuItem2 = new(Helper.Translate("サムネイル変更", CurrentLanguage), SharedImages.GetImage(SharedImages.Images.EditIcon));
                 toolStripMenuItem2.Click += (_, _) =>
                 {
                     OpenFileDialog ofd = new()
@@ -172,7 +172,7 @@ namespace Avatar_Explorer.Forms
                     GenerateAvatarList();
                 };
 
-                ToolStripMenuItem toolStripMenuItem3 = new(Helper.Translate("編集", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.EditIcon));
+                ToolStripMenuItem toolStripMenuItem3 = new(Helper.Translate("編集", CurrentLanguage), SharedImages.GetImage(SharedImages.Images.EditIcon));
                 toolStripMenuItem3.Click += (_, _) =>
                 {
                     AddItem addItem = new(this, item.Type, true, item, null);
@@ -183,7 +183,7 @@ namespace Avatar_Explorer.Forms
                     GenerateCategoryListLeft();
                 };
 
-                ToolStripMenuItem toolStripMenuItem4 = new(Helper.Translate("削除", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.TrashIcon));
+                ToolStripMenuItem toolStripMenuItem4 = new(Helper.Translate("削除", CurrentLanguage), SharedImages.GetImage(SharedImages.Images.TrashIcon));
                 toolStripMenuItem4.Click += (_, _) =>
                 {
                     DialogResult result = MessageBox.Show(Helper.Translate("本当に削除しますか？", CurrentLanguage),
@@ -260,7 +260,7 @@ namespace Avatar_Explorer.Forms
 
                 ContextMenuStrip contextMenuStrip = new();
 
-                ToolStripMenuItem toolStripMenuItem4 = new(Helper.Translate("サムネイル変更", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.EditIcon));
+                ToolStripMenuItem toolStripMenuItem4 = new(Helper.Translate("サムネイル変更", CurrentLanguage), SharedImages.GetImage(SharedImages.Images.EditIcon));
                 toolStripMenuItem4.Click += (_, _) =>
                 {
                     OpenFileDialog ofd = new()
@@ -449,7 +449,7 @@ namespace Avatar_Explorer.Forms
 
                 if (Directory.Exists(item.ItemPath))
                 {
-                    ToolStripMenuItem toolStripMenuItem = new(Helper.Translate("フォルダを開く", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.OpenIcon));
+                    ToolStripMenuItem toolStripMenuItem = new(Helper.Translate("フォルダを開く", CurrentLanguage), SharedImages.GetImage(SharedImages.Images.OpenIcon));
                     toolStripMenuItem.Click += (_, _) =>
                     {
                         if (!Directory.Exists(item.ItemPath))
@@ -467,7 +467,7 @@ namespace Avatar_Explorer.Forms
                 if (item.BoothId != -1)
                 {
                     ToolStripMenuItem toolStripMenuItem =
-                        new(Helper.Translate("Boothリンクのコピー", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.CopyIcon));
+                        new(Helper.Translate("Boothリンクのコピー", CurrentLanguage), SharedImages.GetImage(SharedImages.Images.CopyIcon));
                     toolStripMenuItem.Click += (_, _) =>
                     {
                         try
@@ -483,7 +483,7 @@ namespace Avatar_Explorer.Forms
                     };
 
                     ToolStripMenuItem toolStripMenuItem1 =
-                        new(Helper.Translate("Boothリンクを開く", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.CopyIcon));
+                        new(Helper.Translate("Boothリンクを開く", CurrentLanguage), SharedImages.GetImage(SharedImages.Images.CopyIcon));
                     toolStripMenuItem1.Click += (_, _) =>
                     {
                         try
@@ -507,7 +507,7 @@ namespace Avatar_Explorer.Forms
                 }
 
 
-                ToolStripMenuItem toolStripMenuItem2 = new(Helper.Translate("サムネイル変更", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.EditIcon));
+                ToolStripMenuItem toolStripMenuItem2 = new(Helper.Translate("サムネイル変更", CurrentLanguage), SharedImages.GetImage(SharedImages.Images.EditIcon));
                 toolStripMenuItem2.Click += (_, _) =>
                 {
                     OpenFileDialog ofd = new()
@@ -528,7 +528,7 @@ namespace Avatar_Explorer.Forms
                     GenerateAvatarList();
                 };
 
-                ToolStripMenuItem toolStripMenuItem3 = new(Helper.Translate("編集", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.EditIcon));
+                ToolStripMenuItem toolStripMenuItem3 = new(Helper.Translate("編集", CurrentLanguage), SharedImages.GetImage(SharedImages.Images.EditIcon));
                 toolStripMenuItem3.Click += (_, _) =>
                 {
                     AddItem addItem = new(this, CurrentPath.CurrentSelectedCategory, true, item, null);
@@ -539,7 +539,7 @@ namespace Avatar_Explorer.Forms
                     GenerateCategoryListLeft();
                 };
 
-                ToolStripMenuItem toolStripMenuItem4 = new(Helper.Translate("削除", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.TrashIcon));
+                ToolStripMenuItem toolStripMenuItem4 = new(Helper.Translate("削除", CurrentLanguage), SharedImages.GetImage(SharedImages.Images.TrashIcon));
                 toolStripMenuItem4.Click += (_, _) =>
                 {
                     DialogResult result = MessageBox.Show(Helper.Translate("本当に削除しますか？", CurrentLanguage),
@@ -625,7 +625,7 @@ namespace Avatar_Explorer.Forms
                 button.Location = new Point(0, (70 * index) + 2);
 
                 ContextMenuStrip contextMenuStrip = new();
-                ToolStripMenuItem toolStripMenuItem = new(Helper.Translate("ファイルのパスを開く", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.CopyIcon));
+                ToolStripMenuItem toolStripMenuItem = new(Helper.Translate("ファイルのパスを開く", CurrentLanguage), SharedImages.GetImage(SharedImages.Images.CopyIcon));
                 toolStripMenuItem.Click += (_, _) => { Process.Start("explorer.exe", "/select," + file.FilePath); };
                 contextMenuStrip.Items.Add(toolStripMenuItem);
                 button.ContextMenuStrip = contextMenuStrip;
@@ -726,7 +726,7 @@ namespace Avatar_Explorer.Forms
 
                 if (Directory.Exists(item.ItemPath))
                 {
-                    ToolStripMenuItem toolStripMenuItem = new(Helper.Translate("フォルダを開く", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.OpenIcon));
+                    ToolStripMenuItem toolStripMenuItem = new(Helper.Translate("フォルダを開く", CurrentLanguage), SharedImages.GetImage(SharedImages.Images.OpenIcon));
                     toolStripMenuItem.Click += (_, _) =>
                     {
                         if (!Directory.Exists(item.ItemPath))
@@ -744,7 +744,7 @@ namespace Avatar_Explorer.Forms
                 if (item.BoothId != -1)
                 {
                     ToolStripMenuItem toolStripMenuItem =
-                        new(Helper.Translate("Boothリンクのコピー", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.CopyIcon));
+                        new(Helper.Translate("Boothリンクのコピー", CurrentLanguage), SharedImages.GetImage(SharedImages.Images.CopyIcon));
                     toolStripMenuItem.Click += (_, _) =>
                     {
                         try
@@ -760,7 +760,7 @@ namespace Avatar_Explorer.Forms
                     };
 
                     ToolStripMenuItem toolStripMenuItem1 =
-                        new(Helper.Translate("Boothリンクを開く", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.CopyIcon));
+                        new(Helper.Translate("Boothリンクを開く", CurrentLanguage), SharedImages.GetImage(SharedImages.Images.CopyIcon));
                     toolStripMenuItem1.Click += (_, _) =>
                     {
                         try
@@ -783,7 +783,7 @@ namespace Avatar_Explorer.Forms
                     contextMenuStrip.Items.Add(toolStripMenuItem1);
                 }
 
-                ToolStripMenuItem toolStripMenuItem2 = new(Helper.Translate("サムネイル変更", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.EditIcon));
+                ToolStripMenuItem toolStripMenuItem2 = new(Helper.Translate("サムネイル変更", CurrentLanguage), SharedImages.GetImage(SharedImages.Images.EditIcon));
                 toolStripMenuItem2.Click += (_, _) =>
                 {
                     OpenFileDialog ofd = new()
@@ -804,7 +804,7 @@ namespace Avatar_Explorer.Forms
                     GenerateAvatarList();
                 };
 
-                ToolStripMenuItem toolStripMenuItem3 = new(Helper.Translate("編集", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.EditIcon));
+                ToolStripMenuItem toolStripMenuItem3 = new(Helper.Translate("編集", CurrentLanguage), SharedImages.GetImage(SharedImages.Images.EditIcon));
                 toolStripMenuItem3.Click += (_, _) =>
                 {
                     AddItem addItem = new(this, item.Type, true, item, null);
@@ -815,7 +815,7 @@ namespace Avatar_Explorer.Forms
                     GenerateCategoryListLeft();
                 };
 
-                ToolStripMenuItem toolStripMenuItem4 = new(Helper.Translate("削除", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.TrashIcon));
+                ToolStripMenuItem toolStripMenuItem4 = new(Helper.Translate("削除", CurrentLanguage), SharedImages.GetImage(SharedImages.Images.TrashIcon));
                 toolStripMenuItem4.Click += (_, _) =>
                 {
                     DialogResult result = MessageBox.Show(Helper.Translate("本当に削除しますか？", CurrentLanguage),
@@ -880,7 +880,7 @@ namespace Avatar_Explorer.Forms
                 button.Location = new Point(0, (70 * index) + 2);
 
                 ContextMenuStrip contextMenuStrip = new();
-                ToolStripMenuItem toolStripMenuItem = new(Helper.Translate("ファイルのパスを開く", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.CopyIcon));
+                ToolStripMenuItem toolStripMenuItem = new(Helper.Translate("ファイルのパスを開く", CurrentLanguage), SharedImages.GetImage(SharedImages.Images.CopyIcon));
                 toolStripMenuItem.Click += (_, _) => { Process.Start("explorer.exe", "/select," + file.FilePath); };
                 contextMenuStrip.Items.Add(toolStripMenuItem);
                 button.ContextMenuStrip = contextMenuStrip;

--- a/Forms/Main.cs
+++ b/Forms/Main.cs
@@ -32,11 +32,6 @@ namespace Avatar_Explorer.Forms
         private bool _authorMode;
         private bool _categoryMode;
 
-        // Images
-        private readonly Image _copyImage = Image.FromStream(new MemoryStream(Properties.Resources.CopyIcon));
-        private readonly Image _trashImage = Image.FromStream(new MemoryStream(Properties.Resources.TrashIcon));
-        private readonly Image _editImage = Image.FromStream(new MemoryStream(Properties.Resources.EditIcon));
-        private readonly Image _openImage = Image.FromStream(new MemoryStream(Properties.Resources.OpenIcon));
 
         private Window _openingWindow = Window.Nothing;
 
@@ -121,7 +116,7 @@ namespace Avatar_Explorer.Forms
                 if (item.BoothId != -1)
                 {
                     ToolStripMenuItem toolStripMenuItem =
-                        new(Helper.Translate("Boothリンクのコピー", CurrentLanguage), _copyImage);
+                        new(Helper.Translate("Boothリンクのコピー", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.CopyIcon));
                     toolStripMenuItem.Click += (_, _) =>
                     {
                         try
@@ -137,7 +132,7 @@ namespace Avatar_Explorer.Forms
                     };
 
                     ToolStripMenuItem toolStripMenuItem1 =
-                        new(Helper.Translate("Boothリンクを開く", CurrentLanguage), _copyImage);
+                        new(Helper.Translate("Boothリンクを開く", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.CopyIcon));
                     toolStripMenuItem1.Click += (_, _) =>
                     {
                         try
@@ -156,7 +151,7 @@ namespace Avatar_Explorer.Forms
                     contextMenuStrip.Items.Add(toolStripMenuItem1);
                 }
 
-                ToolStripMenuItem toolStripMenuItem2 = new(Helper.Translate("サムネイル変更", CurrentLanguage), _editImage);
+                ToolStripMenuItem toolStripMenuItem2 = new(Helper.Translate("サムネイル変更", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.EditIcon));
                 toolStripMenuItem2.Click += (_, _) =>
                 {
                     OpenFileDialog ofd = new()
@@ -177,7 +172,7 @@ namespace Avatar_Explorer.Forms
                     GenerateAvatarList();
                 };
 
-                ToolStripMenuItem toolStripMenuItem3 = new(Helper.Translate("編集", CurrentLanguage), _editImage);
+                ToolStripMenuItem toolStripMenuItem3 = new(Helper.Translate("編集", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.EditIcon));
                 toolStripMenuItem3.Click += (_, _) =>
                 {
                     AddItem addItem = new(this, item.Type, true, item, null);
@@ -188,7 +183,7 @@ namespace Avatar_Explorer.Forms
                     GenerateCategoryListLeft();
                 };
 
-                ToolStripMenuItem toolStripMenuItem4 = new(Helper.Translate("削除", CurrentLanguage), _trashImage);
+                ToolStripMenuItem toolStripMenuItem4 = new(Helper.Translate("削除", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.TrashIcon));
                 toolStripMenuItem4.Click += (_, _) =>
                 {
                     DialogResult result = MessageBox.Show(Helper.Translate("本当に削除しますか？", CurrentLanguage),
@@ -265,7 +260,7 @@ namespace Avatar_Explorer.Forms
 
                 ContextMenuStrip contextMenuStrip = new();
 
-                ToolStripMenuItem toolStripMenuItem4 = new(Helper.Translate("サムネイル変更", CurrentLanguage), _editImage);
+                ToolStripMenuItem toolStripMenuItem4 = new(Helper.Translate("サムネイル変更", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.EditIcon));
                 toolStripMenuItem4.Click += (_, _) =>
                 {
                     OpenFileDialog ofd = new()
@@ -454,7 +449,7 @@ namespace Avatar_Explorer.Forms
 
                 if (Directory.Exists(item.ItemPath))
                 {
-                    ToolStripMenuItem toolStripMenuItem = new(Helper.Translate("フォルダを開く", CurrentLanguage), _openImage);
+                    ToolStripMenuItem toolStripMenuItem = new(Helper.Translate("フォルダを開く", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.OpenIcon));
                     toolStripMenuItem.Click += (_, _) =>
                     {
                         if (!Directory.Exists(item.ItemPath))
@@ -472,7 +467,7 @@ namespace Avatar_Explorer.Forms
                 if (item.BoothId != -1)
                 {
                     ToolStripMenuItem toolStripMenuItem =
-                        new(Helper.Translate("Boothリンクのコピー", CurrentLanguage), _copyImage);
+                        new(Helper.Translate("Boothリンクのコピー", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.CopyIcon));
                     toolStripMenuItem.Click += (_, _) =>
                     {
                         try
@@ -488,7 +483,7 @@ namespace Avatar_Explorer.Forms
                     };
 
                     ToolStripMenuItem toolStripMenuItem1 =
-                        new(Helper.Translate("Boothリンクを開く", CurrentLanguage), _copyImage);
+                        new(Helper.Translate("Boothリンクを開く", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.CopyIcon));
                     toolStripMenuItem1.Click += (_, _) =>
                     {
                         try
@@ -512,7 +507,7 @@ namespace Avatar_Explorer.Forms
                 }
 
 
-                ToolStripMenuItem toolStripMenuItem2 = new(Helper.Translate("サムネイル変更", CurrentLanguage), _editImage);
+                ToolStripMenuItem toolStripMenuItem2 = new(Helper.Translate("サムネイル変更", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.EditIcon));
                 toolStripMenuItem2.Click += (_, _) =>
                 {
                     OpenFileDialog ofd = new()
@@ -533,7 +528,7 @@ namespace Avatar_Explorer.Forms
                     GenerateAvatarList();
                 };
 
-                ToolStripMenuItem toolStripMenuItem3 = new(Helper.Translate("編集", CurrentLanguage), _editImage);
+                ToolStripMenuItem toolStripMenuItem3 = new(Helper.Translate("編集", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.EditIcon));
                 toolStripMenuItem3.Click += (_, _) =>
                 {
                     AddItem addItem = new(this, CurrentPath.CurrentSelectedCategory, true, item, null);
@@ -544,7 +539,7 @@ namespace Avatar_Explorer.Forms
                     GenerateCategoryListLeft();
                 };
 
-                ToolStripMenuItem toolStripMenuItem4 = new(Helper.Translate("削除", CurrentLanguage), _trashImage);
+                ToolStripMenuItem toolStripMenuItem4 = new(Helper.Translate("削除", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.TrashIcon));
                 toolStripMenuItem4.Click += (_, _) =>
                 {
                     DialogResult result = MessageBox.Show(Helper.Translate("本当に削除しますか？", CurrentLanguage),
@@ -630,7 +625,7 @@ namespace Avatar_Explorer.Forms
                 button.Location = new Point(0, (70 * index) + 2);
 
                 ContextMenuStrip contextMenuStrip = new();
-                ToolStripMenuItem toolStripMenuItem = new(Helper.Translate("ファイルのパスを開く", CurrentLanguage), _copyImage);
+                ToolStripMenuItem toolStripMenuItem = new(Helper.Translate("ファイルのパスを開く", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.CopyIcon));
                 toolStripMenuItem.Click += (_, _) => { Process.Start("explorer.exe", "/select," + file.FilePath); };
                 contextMenuStrip.Items.Add(toolStripMenuItem);
                 button.ContextMenuStrip = contextMenuStrip;
@@ -731,7 +726,7 @@ namespace Avatar_Explorer.Forms
 
                 if (Directory.Exists(item.ItemPath))
                 {
-                    ToolStripMenuItem toolStripMenuItem = new(Helper.Translate("フォルダを開く", CurrentLanguage), _openImage);
+                    ToolStripMenuItem toolStripMenuItem = new(Helper.Translate("フォルダを開く", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.OpenIcon));
                     toolStripMenuItem.Click += (_, _) =>
                     {
                         if (!Directory.Exists(item.ItemPath))
@@ -749,7 +744,7 @@ namespace Avatar_Explorer.Forms
                 if (item.BoothId != -1)
                 {
                     ToolStripMenuItem toolStripMenuItem =
-                        new(Helper.Translate("Boothリンクのコピー", CurrentLanguage), _copyImage);
+                        new(Helper.Translate("Boothリンクのコピー", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.CopyIcon));
                     toolStripMenuItem.Click += (_, _) =>
                     {
                         try
@@ -765,7 +760,7 @@ namespace Avatar_Explorer.Forms
                     };
 
                     ToolStripMenuItem toolStripMenuItem1 =
-                        new(Helper.Translate("Boothリンクを開く", CurrentLanguage), _copyImage);
+                        new(Helper.Translate("Boothリンクを開く", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.CopyIcon));
                     toolStripMenuItem1.Click += (_, _) =>
                     {
                         try
@@ -788,7 +783,7 @@ namespace Avatar_Explorer.Forms
                     contextMenuStrip.Items.Add(toolStripMenuItem1);
                 }
 
-                ToolStripMenuItem toolStripMenuItem2 = new(Helper.Translate("サムネイル変更", CurrentLanguage), _editImage);
+                ToolStripMenuItem toolStripMenuItem2 = new(Helper.Translate("サムネイル変更", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.EditIcon));
                 toolStripMenuItem2.Click += (_, _) =>
                 {
                     OpenFileDialog ofd = new()
@@ -809,7 +804,7 @@ namespace Avatar_Explorer.Forms
                     GenerateAvatarList();
                 };
 
-                ToolStripMenuItem toolStripMenuItem3 = new(Helper.Translate("編集", CurrentLanguage), _editImage);
+                ToolStripMenuItem toolStripMenuItem3 = new(Helper.Translate("編集", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.EditIcon));
                 toolStripMenuItem3.Click += (_, _) =>
                 {
                     AddItem addItem = new(this, item.Type, true, item, null);
@@ -820,7 +815,7 @@ namespace Avatar_Explorer.Forms
                     GenerateCategoryListLeft();
                 };
 
-                ToolStripMenuItem toolStripMenuItem4 = new(Helper.Translate("削除", CurrentLanguage), _trashImage);
+                ToolStripMenuItem toolStripMenuItem4 = new(Helper.Translate("削除", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.TrashIcon));
                 toolStripMenuItem4.Click += (_, _) =>
                 {
                     DialogResult result = MessageBox.Show(Helper.Translate("本当に削除しますか？", CurrentLanguage),
@@ -885,7 +880,7 @@ namespace Avatar_Explorer.Forms
                 button.Location = new Point(0, (70 * index) + 2);
 
                 ContextMenuStrip contextMenuStrip = new();
-                ToolStripMenuItem toolStripMenuItem = new(Helper.Translate("ファイルのパスを開く", CurrentLanguage), _copyImage);
+                ToolStripMenuItem toolStripMenuItem = new(Helper.Translate("ファイルのパスを開く", CurrentLanguage), SharedImages.GetSharedImage(SharedImages.Images.CopyIcon));
                 toolStripMenuItem.Click += (_, _) => { Process.Start("explorer.exe", "/select," + file.FilePath); };
                 contextMenuStrip.Items.Add(toolStripMenuItem);
                 button.ContextMenuStrip = contextMenuStrip;
@@ -1094,7 +1089,10 @@ namespace Avatar_Explorer.Forms
             {
                 if (AvatarItemExplorer.Controls[i].Name != "StartLabel")
                 {
+                    var control = AvatarItemExplorer.Controls[i];
                     AvatarItemExplorer.Controls.RemoveAt(i);
+                    // メモリの開放を行う
+                    control.Dispose();
                 }
                 else
                 {


### PR DESCRIPTION
ボタンのメモリ開放周りを修正しました。
ボタン左の画像と、画像ホバー時のサムネイルが対象です。
（修正前は4K画像を何枚かホバーしたら、メモリ使用があっという間に数GB行ってました…）

あと、メモリ開放対象の画像かを確認する処理を実装するため、
メインとヘルパーで定義されていた画像を1つのクラスにまとめました。